### PR TITLE
Fix TypeScript compile errors

### DIFF
--- a/app/(auth)/login.tsx
+++ b/app/(auth)/login.tsx
@@ -69,11 +69,9 @@ export default function LoginPage() {
         await AsyncStorage.setItem('token', response.accessToken);
       }
   
-      // Mettre à jour l'utilisateur via le contexte
-      await setCurrentUser({
-        id: response.id,
-        email: response.email,
-      });
+      // Récupérer les informations complètes de l'utilisateur puis mettre à jour le contexte
+      const userInfo = await authService.getUserInfo();
+      await setCurrentUser(userInfo);
       
       router.push("/(app)/exercise");
     } catch (err: any) {

--- a/components/ExternalLink.tsx
+++ b/components/ExternalLink.tsx
@@ -10,7 +10,6 @@ export function ExternalLink(
     <Link
       target="_blank"
       {...props}
-      // @ts-expect-error: External URLs are not typed.
       href={props.href}
       onPress={(e) => {
         if (Platform.OS !== 'web') {

--- a/components/TrainingDetails.tsx
+++ b/components/TrainingDetails.tsx
@@ -61,7 +61,7 @@ import '@/global.css';
     }, [trainingId, visible, isEditing]);
 
     const fetchAvailableExercises = async () => {
-      if (!currentUser) return;
+      if (!currentUser || currentUser.id === null) return;
       
       try {
         const exercises = await exerciseService.findAllByUserId(currentUser.id);
@@ -149,7 +149,7 @@ import '@/global.css';
           totalMinutesOfRest: editedExercises.reduce((total, ex) => total + (ex.restTimeInMinutes || 0), 0)
         };
         
-        if (!currentUser) {
+        if (!currentUser || currentUser.id === null) {
           showModal('error', 'Erreur', 'Utilisateur non connecté.');
           return;
         }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,17 @@
 {
-  "extends": "expo/tsconfig.base",
   "compilerOptions": {
+    "allowJs": true,
+    "esModuleInterop": true,
+    "jsx": "react-native",
+    "lib": ["DOM", "ESNext"],
+    "module": "esnext",
+    "moduleDetection": "force",
+    "moduleResolution": "bundler",
+    "customConditions": ["react-native"],
+    "noEmit": true,
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "target": "ESNext",
     "strict": true,
     "paths": {
       "@/*": [


### PR DESCRIPTION
## Summary
- replace expo config with custom tsconfig to avoid unsupported module option
- fetch full user info on login
- clean up ExternalLink
- check current user ID before training operations

## Testing
- `npx tsc --noEmit`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688b19030a4c8327a3bd01deed7711fe